### PR TITLE
Fix invalid json

### DIFF
--- a/config.json
+++ b/config.json
@@ -19,7 +19,7 @@
       "slug": "hello-world",
       "difficulty": 1,
       "topics": [
-        "optional values"
+        "optional values",
         "text formatting"
       ]
     }


### PR DESCRIPTION
208e40bf26d7e58510d10b4c3260bbe9815d4922 introduced invalid json in the
config file. This in turn seems to have been an attempt to address missing
exercise slugs, introduced in c9215d14c9a630cf5bcb8da08df6ccb18f7d2761